### PR TITLE
oss-fuzzers: add first fuzzer.

### DIFF
--- a/oss-fuzzers/fuzz_parse.c
+++ b/oss-fuzzers/fuzz_parse.c
@@ -1,0 +1,25 @@
+#include <stdio.h>
+#include <unistd.h>
+
+#include <gpac/internal/isomedia_dev.h>
+#include <gpac/constants.h>
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+    char filename[256];
+    sprintf(filename, "/tmp/libfuzzer.%d", getpid());
+
+    FILE *fp = fopen(filename, "wb");
+    if (!fp) {
+        return 0;
+    }
+    fwrite(data, size, 1, fp);
+    fclose(fp);
+
+    GF_ISOFile *movie = NULL;
+    movie = gf_isom_open_file(filename, GF_ISOM_OPEN_READ_DUMP, NULL);
+    if (movie != NULL) {
+        gf_isom_close(movie);
+    }
+    unlink(filename);
+    return 0;
+}


### PR DESCRIPTION
Cross-referencing https://github.com/gpac/gpac/pull/1697 @aureliendavid 

Moving the fuzzers from oss-fuzz (https://github.com/google/oss-fuzz/tree/master/projects/gpac) over to the gpac's own repositories and starting with the fuzzer itself.