### PR TITLE
fix include by absolute path

### DIFF
--- a/oss-fuzzers/fuzz_m2ts_probe.c
+++ b/oss-fuzzers/fuzz_m2ts_probe.c
@@ -1,4 +1,4 @@
-#include "/src/gpac/include/gpac/mpegts.h"
+#include <gpac/mpegts.h>
 #include <stdio.h>
 #include <unistd.h>
 #include <string.h>


### PR DESCRIPTION
While the absolute path should work for OSS-Fuzz, it makes it harder to run the fuzzers outside OSS-Fuzz. Including relative to include paths should make building fuzzers simpler. I don't expect this to break the OSS-Fuzz integration because their [build script](https://github.com/google/oss-fuzz/blob/40b81bdfb93650e2e0b6cde345204f28136e4b91/projects/gpac/build.sh#L28) also correctly sets up include paths.